### PR TITLE
fix notebook error

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -20,4 +20,4 @@ dependencies:
   - nb_conda_kernels=2.3.1
   - pip:
     - metaflow-card-html==1.0.1
-    - metaflow-card-notebook==1.0.1
+    - metaflow-card-notebook==1.0.7


### PR DESCRIPTION
There is some kind of breaking change in nbformat between minor versions.  The fix is to relax the pinned versions in metaflow-card-notebook to allow pip the room not to downgrade nbformat.  

I cut a release of metaflow-card-notebook to allow this

cc: @savingoyal @hugobowne 